### PR TITLE
Give credit to original authors in manifest

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,7 @@
   <maintainer email="clalancette@openrobotics.org">
     Chris Lalancette
   </maintainer>
+  <author>The Cartographer Authors</author>
   <license>Apache 2.0</license>
 
   <url>https://github.com/googlecartographer/cartographer</url>


### PR DESCRIPTION
When replacing a maintainer we should create an author tag to credit the previous maintainer