### PR TITLE
use upstream ceres

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -37,7 +37,7 @@
   <build_depend>python-sphinx</build_depend>
 
   <depend>boost</depend>
-  <depend>ceres_solver</depend>
+  <depend>ceres-solver</depend>
   <depend>eigen</depend>
   <depend>libcairo2-dev</depend>
   <depend>libgflags-dev</depend>


### PR DESCRIPTION
see https://github.com/ros2/cartographer/pull/1#discussion_r131553939

This will need testing just to make sure that cartographer does build and work properly with ceres-solver 1.11 provided by xenial. If it works it will save us quite some build time on the turtlebot jobs