### PR TITLE
Use the existing rosdep key for ceres-solver.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -37,7 +37,7 @@
   <build_depend>python-sphinx</build_depend>
 
   <depend>boost</depend>
-  <depend>ceres-solver</depend>
+  <depend>libceres-dev</depend>
   <depend>eigen</depend>
   <depend>libcairo2-dev</depend>
   <depend>libgflags-dev</depend>


### PR DESCRIPTION
By my understanding, the actual rosdep key for ceres-solver is libceres-dev

https://github.com/ros/rosdistro/blob/1321c9b1915f8ac90de14272e372da820b7dc1c0/rosdep/base.yaml#L1426-L1432