### PR TITLE
Depend on cmake when using the cmake build type.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -35,6 +35,8 @@
   <!-- TODO(clalancette): disabling dependency until we reenable the tests -->
   <!-- <build_depend>google-mock</build_depend> -->
   <build_depend>python-sphinx</build_depend>
+  
+  <buildtool_depend>cmake</buildtool_depend>
 
   <depend>boost</depend>
   <depend>eigen</depend>


### PR DESCRIPTION
This issue was being masked by a spurious low-level buildtool_export_depend on cmake.