### PR TITLE
fix compiler warning about comparison between signed and unsigned in test

### DIFF
--- a/cartographer/io/serialization_format_migration_test.cc
+++ b/cartographer/io/serialization_format_migration_test.cc
@@ -90,7 +90,7 @@ TEST_F(MigrationTest, MigrationAddsHeaderAsFirstMessage) {
 
   mapping::proto::SerializationHeader header;
   EXPECT_TRUE(TextFormat::ParseFromString(output_messages_[0], &header));
-  EXPECT_THAT(header.format_version(), Eq(1));
+  EXPECT_THAT(header.format_version(), Eq<uint32>(1));
 }
 
 TEST_F(MigrationTest, SerializedDataOrderIsCorrect) {


### PR DESCRIPTION
Before: http://build.ros2.org/view/Edev/job/Edev__cartographer__ubuntu_bionic_amd64/3/warnings24Result/