### PR TITLE
restrict boost dependencies to the ones used

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -41,7 +41,7 @@
   <build_depend>google-mock</build_depend>
   <build_depend>python-sphinx</build_depend>
 
-  <depend>boost</depend>
+  <depend>libboost-iostreams-dev</depend>
   <depend>eigen</depend>
   <depend>libcairo2-dev</depend>
   <depend>libceres-dev</depend>

--- a/scripts/install_debs_cmake.sh
+++ b/scripts/install_debs_cmake.sh
@@ -24,7 +24,7 @@ sudo apt-get install -y \
     g++ \
     git \
     google-mock \
-    libboost-all-dev \
+    libboost-iostreams-dev \
     libcairo2-dev \
     libeigen3-dev \
     libgflags-dev \

--- a/scripts/install_debs_cmake.sh
+++ b/scripts/install_debs_cmake.sh
@@ -24,7 +24,7 @@ sudo apt-get install -y \
     g++ \
     git \
     google-mock \
-    libboost-iostreams-dev \
+    libboost-all-dev \
     libcairo2-dev \
     libeigen3-dev \
     libgflags-dev \


### PR DESCRIPTION
In the spirit of https://discourse.ros.org/t/generating-dev-and-runtime-artefacts-from-ros-packages/12448 and removing the use of the blanket `boost` rosdep key as a dependency.

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>