### PR TITLE
fix compiler error about FindGMock.cmake in test

### DIFF
--- a/cmake/modules/FindGMock.cmake
+++ b/cmake/modules/FindGMock.cmake
@@ -30,6 +30,25 @@ if(NOT GMock_FOUND)
     PATHS
       /usr
   )
+  if(GMOCK_LIBRARIES)
+    find_library(GMOCK_LIBRARY
+      NAMES gmock
+      HINTS
+        ENV GMOCK_DIR
+      PATH_SUFFIXES lib
+      PATHS
+        /usr
+    )
+    find_library(GTEST_LIBRARY
+      NAMES gtest
+      HINTS
+        ENV GMOCK_DIR
+      PATH_SUFFIXES lib
+      PATHS
+        /usr
+    )
+    list(APPEND GMOCK_LIBRARIES ${GMOCK_LIBRARY} ${GTEST_LIBRARY})
+  endif()
 
   # Find system-wide gtest header.
   find_path(GTEST_INCLUDE_DIRS gtest/gtest.h
@@ -57,9 +76,8 @@ if(NOT GMock_FOUND)
         add_subdirectory(${GMOCK_SRC_DIR} "${CMAKE_CURRENT_BINARY_DIR}/gmock"
           EXCLUDE_FROM_ALL)
       endif()
-      # The next line is needed for Ubuntu Trusty.
-      set(GMOCK_INCLUDE_DIRS "${GMOCK_SRC_DIR}/gtest/include")
       set(GMOCK_LIBRARIES gmock_main)
+      set(GMOCK_INCLUDE_DIRS ${GMOCK_SRC_DIR}/include)
     endif()
   endif()
 


### PR DESCRIPTION
There are 1 commits in here to get cartographer building on Ubuntu 20.04 and ROS2_Foxy:
1. fix compiler error about FindGMock.cmake in test
