### PR TITLE
Update cartographer to deal with newer ceres

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 project(cartographer)
 

--- a/cartographer/mapping/internal/3d/rotation_parameterization.h
+++ b/cartographer/mapping/internal/3d/rotation_parameterization.h
@@ -24,6 +24,7 @@
 namespace cartographer {
 namespace mapping {
 
+#if CERES_VERSION_MAJOR > 2 || CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 1
 // Provides operations used to create a Ceres Manifold with a 4-D ambient
 // space and a 1-D tangent space that represents a yaw rotation only.
 struct YawOnlyQuaternionOperations {
@@ -88,12 +89,44 @@ struct ConstantYawQuaternionOperations {
     return true;
   }
 };
+#else
+struct YawOnlyQuaternionPlus {
+  template <typename T>
+  bool operator()(const T* x, const T* delta, T* x_plus_delta) const {
+    const T clamped_delta = common::Clamp(delta[0], T(-0.5), T(0.5));
+    T q_delta[4];
+    q_delta[0] = ceres::sqrt(1. - clamped_delta * clamped_delta);
+    q_delta[1] = T(0.);
+    q_delta[2] = T(0.);
+    q_delta[3] = clamped_delta;
+    ceres::QuaternionProduct(q_delta, x, x_plus_delta);
+    return true;
+  }
+};
 
-// Type aliases used to create manifolds.
-using YawOnlyQuaternionManifold =
-    ceres::AutoDiffManifold<YawOnlyQuaternionOperations, 4, 1>;
-using ConstantYawQuaternionManifold =
-    ceres::AutoDiffManifold<ConstantYawQuaternionOperations, 4, 2>;
+struct ConstantYawQuaternionPlus {
+  template <typename T>
+  bool operator()(const T* x, const T* delta, T* x_plus_delta) const {
+    const T delta_norm =
+        ceres::sqrt(common::Pow2(delta[0]) + common::Pow2(delta[1]));
+    const T sin_delta_over_delta =
+        delta_norm < 1e-6 ? T(1.) : ceres::sin(delta_norm) / delta_norm;
+    T q_delta[4];
+    q_delta[0] = delta_norm < 1e-6 ? T(1.) : ceres::cos(delta_norm);
+    q_delta[1] = sin_delta_over_delta * delta[0];
+    q_delta[2] = sin_delta_over_delta * delta[1];
+    q_delta[3] = T(0.);
+    // We apply the 'delta' which is interpreted as an angle-axis rotation
+    // vector in the xy-plane of the submap frame. This way we can align to
+    // gravity because rotations around the z-axis in the submap frame do not
+    // change gravity alignment, while disallowing random rotations of the map
+    // that have nothing to do with gravity alignment (i.e. we disallow steps
+    // just changing "yaw" of the complete map).
+    ceres::QuaternionProduct(x, q_delta, x_plus_delta);
+    return true;
+  }
+};
+#endif
 
 }  // namespace mapping
 }  // namespace cartographer

--- a/cartographer/mapping/internal/3d/rotation_parameterization_test.cc
+++ b/cartographer/mapping/internal/3d/rotation_parameterization_test.cc
@@ -1,0 +1,48 @@
+#include "cartographer/mapping/internal/3d/rotation_parameterization.h"
+
+#include "ceres/manifold_test_utils.h"
+#include "gtest/gtest.h"
+
+namespace cartographer::mapping {
+
+template <typename T>
+class RotationParameterizationTests : public ::testing::Test {};
+
+using TestTypes =
+    ::testing::Types<YawOnlyQuaternionManifold, ConstantYawQuaternionManifold>;
+TYPED_TEST_SUITE(RotationParameterizationTests, TestTypes);
+
+TYPED_TEST(RotationParameterizationTests, ManifoldInvariantsHold) {
+  const TypeParam manifold;
+
+  constexpr static int kNumTrials = 10;
+  constexpr static double kTolerance = 1.e-5;
+  const std::vector<double> delta_magnitutes = {0.0, 1.e-9, 1.e-3, 0.5};
+  for (int trial = 0; trial < kNumTrials; ++trial) {
+    const Eigen::VectorXd x =
+        Eigen::VectorXd::Random(manifold.AmbientSize()).normalized();
+
+    for (const double delta_magnitude : delta_magnitutes) {
+      const Eigen::VectorXd delta =
+          Eigen::VectorXd::Random(manifold.TangentSize()) * delta_magnitude;
+      EXPECT_THAT(manifold, ceres::XPlusZeroIsXAt(x, kTolerance));
+      EXPECT_THAT(manifold, ceres::XMinusXIsZeroAt(x, kTolerance));
+      EXPECT_THAT(manifold, ceres::MinusPlusIsIdentityAt(x, delta, kTolerance));
+      const Eigen::VectorXd zero_tangent =
+          Eigen::VectorXd::Zero(manifold.TangentSize());
+      EXPECT_THAT(manifold,
+                  ceres::MinusPlusIsIdentityAt(x, zero_tangent, kTolerance));
+
+      Eigen::VectorXd y(manifold.AmbientSize());
+      ASSERT_TRUE(manifold.Plus(x.data(), delta.data(), y.data()));
+      EXPECT_THAT(manifold, ceres::PlusMinusIsIdentityAt(x, x, kTolerance));
+      EXPECT_THAT(manifold, ceres::PlusMinusIsIdentityAt(x, y, kTolerance));
+      EXPECT_THAT(manifold, ceres::HasCorrectPlusJacobianAt(x, kTolerance));
+      EXPECT_THAT(manifold, ceres::HasCorrectMinusJacobianAt(x, kTolerance));
+      EXPECT_THAT(manifold,
+                  ceres::MinusPlusJacobianIsIdentityAt(x, kTolerance));
+    }
+  }
+}
+
+}  // namespace cartographer::mapping

--- a/cartographer/mapping/internal/3d/rotation_parameterization_test.cc
+++ b/cartographer/mapping/internal/3d/rotation_parameterization_test.cc
@@ -1,3 +1,4 @@
+#if CERES_VERSION_MAJOR > 2 || CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 1
 #include "cartographer/mapping/internal/3d/rotation_parameterization.h"
 
 #include "ceres/manifold_test_utils.h"
@@ -9,7 +10,7 @@ template <typename T>
 class RotationParameterizationTests : public ::testing::Test {};
 
 using TestTypes =
-    ::testing::Types<YawOnlyQuaternionManifold, ConstantYawQuaternionManifold>;
+    ::testing::Types<ceres::AutoDiffManifold<YawOnlyQuaternionOperations, 4, 1>, ceres::AutoDiffManifold<ConstantYawQuaternionOperations, 4, 2>>;
 TYPED_TEST_SUITE(RotationParameterizationTests, TestTypes);
 
 TYPED_TEST(RotationParameterizationTests, ManifoldInvariantsHold) {
@@ -46,3 +47,4 @@ TYPED_TEST(RotationParameterizationTests, ManifoldInvariantsHold) {
 }
 
 }  // namespace cartographer::mapping
+#endif

--- a/cartographer/mapping/internal/3d/scan_matching/ceres_scan_matcher_3d.cc
+++ b/cartographer/mapping/internal/3d/scan_matching/ceres_scan_matcher_3d.cc
@@ -31,6 +31,7 @@
 #include "cartographer/transform/rigid_transform.h"
 #include "cartographer/transform/transform.h"
 #include "ceres/ceres.h"
+#include "ceres/manifold.h"
 #include "glog/logging.h"
 
 namespace cartographer {
@@ -98,11 +99,10 @@ void CeresScanMatcher3D::Match(
   optimization::CeresPose ceres_pose(
       initial_pose_estimate, nullptr /* translation_parameterization */,
       options_.only_optimize_yaw()
-          ? std::unique_ptr<ceres::LocalParameterization>(
-                absl::make_unique<ceres::AutoDiffLocalParameterization<
-                    YawOnlyQuaternionPlus, 4, 1>>())
-          : std::unique_ptr<ceres::LocalParameterization>(
-                absl::make_unique<ceres::QuaternionParameterization>()),
+          ? std::unique_ptr<ceres::Manifold>(
+                absl::make_unique<YawOnlyQuaternionManifold>())
+          : std::unique_ptr<ceres::Manifold>(
+                absl::make_unique<ceres::QuaternionManifold>()),
       &problem);
 
   CHECK_EQ(options_.occupied_space_weight_size(),

--- a/cartographer/mapping/internal/3d/scan_matching/ceres_scan_matcher_3d.cc
+++ b/cartographer/mapping/internal/3d/scan_matching/ceres_scan_matcher_3d.cc
@@ -31,7 +31,9 @@
 #include "cartographer/transform/rigid_transform.h"
 #include "cartographer/transform/transform.h"
 #include "ceres/ceres.h"
+#if CERES_VERSION_MAJOR > 2 || CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 1
 #include "ceres/manifold.h"
+#endif
 #include "glog/logging.h"
 
 namespace cartographer {
@@ -96,14 +98,26 @@ void CeresScanMatcher3D::Match(
     transform::Rigid3d* const pose_estimate,
     ceres::Solver::Summary* const summary) const {
   ceres::Problem problem;
+#if CERES_VERSION_MAJOR > 2 || CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 1
   optimization::CeresPose ceres_pose(
       initial_pose_estimate, nullptr /* translation_parameterization */,
       options_.only_optimize_yaw()
           ? std::unique_ptr<ceres::Manifold>(
-                absl::make_unique<YawOnlyQuaternionManifold>())
+                absl::make_unique<ceres::AutoDiffManifold<YawOnlyQuaternionOperations, 4, 1>>())
           : std::unique_ptr<ceres::Manifold>(
                 absl::make_unique<ceres::QuaternionManifold>()),
       &problem);
+#else
+  optimization::CeresPose ceres_pose(
+      initial_pose_estimate, nullptr /* translation_parameterization */,
+      options_.only_optimize_yaw()
+          ? std::unique_ptr<ceres::LocalParameterization>(
+                absl::make_unique<ceres::AutoDiffLocalParameterization<
+                    YawOnlyQuaternionPlus, 4, 1>>())
+          : std::unique_ptr<ceres::LocalParameterization>(
+                absl::make_unique<ceres::QuaternionParameterization>()),
+      &problem);
+#endif
 
   CHECK_EQ(options_.occupied_space_weight_size(),
            point_clouds_and_hybrid_grids.size());

--- a/cartographer/mapping/internal/eigen_quaterniond_from_two_vectors.h
+++ b/cartographer/mapping/internal/eigen_quaterniond_from_two_vectors.h
@@ -17,7 +17,18 @@
 #ifndef CARTOGRAPHER_MAPPING_EIGEN_QUATERNIOND_FROM_TWO_VECTORS_H_
 #define CARTOGRAPHER_MAPPING_EIGEN_QUATERNIOND_FROM_TWO_VECTORS_H_
 
+// When using Eigen 3.4.0 on Ubuntu 24.04 on an x86_64 machine and
+// compiling with -O3 -NDEBUG, we get a warning that an SSE function
+// deep within Eigen might be used uninitialized.  This seems like
+// a spurious warning, so just ignore it for now.
+#ifdef __linux__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 #include "Eigen/Geometry"
+#ifdef __linux__
+#pragma GCC diagnostic pop
+#endif
 
 namespace cartographer {
 namespace mapping {

--- a/cartographer/mapping/internal/imu_based_pose_extrapolator.cc
+++ b/cartographer/mapping/internal/imu_based_pose_extrapolator.cc
@@ -28,7 +28,9 @@
 #include "cartographer/mapping/internal/optimization/cost_functions/spa_cost_function_3d.h"
 #include "cartographer/mapping/pose_graph_interface.h"
 #include "cartographer/transform/transform.h"
+#if CERES_VERSION_MAJOR > 2 || CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 1
 #include "ceres/manifold.h"
+#endif
 #include "glog/logging.h"
 
 namespace cartographer {
@@ -136,9 +138,16 @@ ImuBasedPoseExtrapolator::ExtrapolatePosesWithGravity(
 
   // Track gravity alignment over time and use this as a frame here so that
   // we can estimate the gravity alignment of the current pose.
+#if CERES_VERSION_MAJOR > 2 || CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 1
   optimization::CeresPose gravity_from_local(
       gravity_from_local_, nullptr,
       absl::make_unique<ceres::QuaternionManifold>(), &problem);
+#else
+  optimization::CeresPose gravity_from_local(
+      gravity_from_local_, nullptr,
+      absl::make_unique<ceres::QuaternionParameterization>(), &problem);
+#endif
+
   // Use deque so addresses stay constant during problem formulation.
   std::deque<optimization::CeresPose> nodes;
   std::vector<common::Time> node_times;
@@ -161,9 +170,10 @@ ImuBasedPoseExtrapolator::ExtrapolatePosesWithGravity(
       gravity_from_node = gravity_from_local_ * timed_pose.transform;
     }
 
+#if CERES_VERSION_MAJOR > 2 || CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 1
     if (is_last) {
       nodes.emplace_back(gravity_from_node, nullptr,
-                         absl::make_unique<ConstantYawQuaternionManifold>(),
+                         absl::make_unique<ceres::AutoDiffManifold<ConstantYawQuaternionOperations, 4, 2>>(),
                          &problem);
       problem.SetParameterBlockConstant(nodes.back().translation());
     } else {
@@ -171,6 +181,19 @@ ImuBasedPoseExtrapolator::ExtrapolatePosesWithGravity(
                          absl::make_unique<ceres::QuaternionManifold>(),
                          &problem);
     }
+#else
+    if (is_last) {
+      nodes.emplace_back(gravity_from_node, nullptr,
+                         absl::make_unique<ceres::AutoDiffLocalParameterization<
+                             ConstantYawQuaternionPlus, 4, 2>>(),
+                         &problem);
+      problem.SetParameterBlockConstant(nodes.back().translation());
+    } else {
+      nodes.emplace_back(gravity_from_node, nullptr,
+                         absl::make_unique<ceres::QuaternionParameterization>(),
+                         &problem);
+    }
+#endif
   }
 
   double gravity_constant = 9.8;
@@ -199,9 +222,15 @@ ImuBasedPoseExtrapolator::ExtrapolatePosesWithGravity(
           gravity_constant * Eigen::Vector3d::UnitZ(), time, imu_data_,
           &imu_it_prev_prev)
           .pose;
+#if CERES_VERSION_MAJOR > 2 || CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 1
   nodes.emplace_back(initial_estimate, nullptr,
                      absl::make_unique<ceres::QuaternionManifold>(),
                      &problem);
+#else
+  nodes.emplace_back(initial_estimate, nullptr,
+                     absl::make_unique<ceres::QuaternionParameterization>(),
+                     &problem);
+#endif
   node_times.push_back(time);
 
   // Add cost functions for node constraints.
@@ -222,8 +251,13 @@ ImuBasedPoseExtrapolator::ExtrapolatePosesWithGravity(
 
   std::array<double, 4> imu_calibration{{1., 0., 0., 0.}};
 
+#if CERES_VERSION_MAJOR > 2 || CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 1
   problem.AddParameterBlock(imu_calibration.data(), 4,
                             new ceres::QuaternionManifold());
+#else
+  problem.AddParameterBlock(imu_calibration.data(), 4,
+                            new ceres::QuaternionParameterization());
+#endif
   problem.SetParameterBlockConstant(imu_calibration.data());
 
   auto imu_it = imu_data_.begin();

--- a/cartographer/mapping/internal/optimization/ceres_pose.cc
+++ b/cartographer/mapping/internal/optimization/ceres_pose.cc
@@ -29,14 +29,14 @@ CeresPose::Data FromPose(const transform::Rigid3d& pose) {
 
 CeresPose::CeresPose(
     const transform::Rigid3d& pose,
-    std::unique_ptr<ceres::LocalParameterization> translation_parametrization,
-    std::unique_ptr<ceres::LocalParameterization> rotation_parametrization,
+    std::unique_ptr<ceres::Manifold> translation_manifold,
+    std::unique_ptr<ceres::Manifold> rotation_manifold,
     ceres::Problem* problem)
     : data_(std::make_shared<CeresPose::Data>(FromPose(pose))) {
   problem->AddParameterBlock(data_->translation.data(), 3,
-                             translation_parametrization.release());
+                             translation_manifold.release());
   problem->AddParameterBlock(data_->rotation.data(), 4,
-                             rotation_parametrization.release());
+                             rotation_manifold.release());
 }
 
 const transform::Rigid3d CeresPose::ToRigid() const {

--- a/cartographer/mapping/internal/optimization/ceres_pose.cc
+++ b/cartographer/mapping/internal/optimization/ceres_pose.cc
@@ -27,6 +27,7 @@ CeresPose::Data FromPose(const transform::Rigid3d& pose) {
                            pose.rotation().y(), pose.rotation().z()}}};
 }
 
+#if CERES_VERSION_MAJOR > 2 || CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 1
 CeresPose::CeresPose(
     const transform::Rigid3d& pose,
     std::unique_ptr<ceres::Manifold> translation_manifold,
@@ -38,6 +39,19 @@ CeresPose::CeresPose(
   problem->AddParameterBlock(data_->rotation.data(), 4,
                              rotation_manifold.release());
 }
+#else
+CeresPose::CeresPose(
+    const transform::Rigid3d& pose,
+    std::unique_ptr<ceres::LocalParameterization> translation_parametrization,
+    std::unique_ptr<ceres::LocalParameterization> rotation_parametrization,
+    ceres::Problem* problem)
+    : data_(std::make_shared<CeresPose::Data>(FromPose(pose))) {
+  problem->AddParameterBlock(data_->translation.data(), 3,
+                             translation_parametrization.release());
+  problem->AddParameterBlock(data_->rotation.data(), 4,
+                             rotation_parametrization.release());
+}
+#endif
 
 const transform::Rigid3d CeresPose::ToRigid() const {
   return transform::Rigid3d::FromArrays(data_->rotation, data_->translation);

--- a/cartographer/mapping/internal/optimization/ceres_pose.h
+++ b/cartographer/mapping/internal/optimization/ceres_pose.h
@@ -23,6 +23,7 @@
 #include "Eigen/Core"
 #include "cartographer/transform/rigid_transform.h"
 #include "ceres/ceres.h"
+#include "ceres/manifold.h"
 
 namespace cartographer {
 namespace mapping {
@@ -31,9 +32,9 @@ namespace optimization {
 class CeresPose {
  public:
   CeresPose(
-      const transform::Rigid3d& rigid,
-      std::unique_ptr<ceres::LocalParameterization> translation_parametrization,
-      std::unique_ptr<ceres::LocalParameterization> rotation_parametrization,
+      const transform::Rigid3d& pose,
+      std::unique_ptr<ceres::Manifold> translation_manifold,
+      std::unique_ptr<ceres::Manifold> rotation_manifold,
       ceres::Problem* problem);
 
   const transform::Rigid3d ToRigid() const;

--- a/cartographer/mapping/internal/optimization/ceres_pose.h
+++ b/cartographer/mapping/internal/optimization/ceres_pose.h
@@ -23,7 +23,9 @@
 #include "Eigen/Core"
 #include "cartographer/transform/rigid_transform.h"
 #include "ceres/ceres.h"
+#if CERES_VERSION_MAJOR > 2 || CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 1
 #include "ceres/manifold.h"
+#endif
 
 namespace cartographer {
 namespace mapping {
@@ -31,11 +33,19 @@ namespace optimization {
 
 class CeresPose {
  public:
+#if CERES_VERSION_MAJOR > 2 || CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 1
   CeresPose(
       const transform::Rigid3d& pose,
       std::unique_ptr<ceres::Manifold> translation_manifold,
       std::unique_ptr<ceres::Manifold> rotation_manifold,
       ceres::Problem* problem);
+#else
+  CeresPose(
+      const transform::Rigid3d& rigid,
+      std::unique_ptr<ceres::LocalParameterization> translation_parametrization,
+      std::unique_ptr<ceres::LocalParameterization> rotation_parametrization,
+      ceres::Problem* problem);
+#endif
 
   const transform::Rigid3d ToRigid() const;
 

--- a/cartographer/mapping/internal/optimization/optimization_problem_2d.cc
+++ b/cartographer/mapping/internal/optimization/optimization_problem_2d.cc
@@ -144,8 +144,8 @@ void AddLandmarkCostFunctions(
                                          *prev_node_pose, *next_node_pose);
         C_landmarks->emplace(
             landmark_id,
-            CeresPose(starting_point, nullptr /* translation_parametrization */,
-                      absl::make_unique<ceres::QuaternionParameterization>(),
+            CeresPose(starting_point, nullptr /* translation_manifold */,
+                      absl::make_unique<ceres::QuaternionManifold>(),
                       problem));
         // Set landmark constant if it is frozen.
         if (landmark_node.second.frozen) {

--- a/cartographer/mapping/internal/optimization/optimization_problem_2d.cc
+++ b/cartographer/mapping/internal/optimization/optimization_problem_2d.cc
@@ -142,11 +142,19 @@ void AddLandmarkCostFunctions(
                 ? landmark_node.second.global_landmark_pose.value()
                 : GetInitialLandmarkPose(observation, prev->data, next->data,
                                          *prev_node_pose, *next_node_pose);
+#if CERES_VERSION_MAJOR > 2 || CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 1
         C_landmarks->emplace(
             landmark_id,
             CeresPose(starting_point, nullptr /* translation_manifold */,
                       absl::make_unique<ceres::QuaternionManifold>(),
                       problem));
+#else
+        C_landmarks->emplace(
+            landmark_id,
+            CeresPose(starting_point, nullptr /* translation_parametrization */,
+                      absl::make_unique<ceres::QuaternionParameterization>(),
+                      problem));
+#endif
         // Set landmark constant if it is frozen.
         if (landmark_node.second.frozen) {
           problem->SetParameterBlockConstant(

--- a/cartographer/mapping/internal/optimization/optimization_problem_3d.cc
+++ b/cartographer/mapping/internal/optimization/optimization_problem_3d.cc
@@ -158,11 +158,19 @@ void AddLandmarkCostFunctions(
                 ? landmark_node.second.global_landmark_pose.value()
                 : GetInitialLandmarkPose(observation, prev->data, next->data,
                                          *prev_node_pose, *next_node_pose);
+#if CERES_VERSION_MAJOR > 2 || CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 1
         C_landmarks->emplace(
             landmark_id,
             CeresPose(starting_point, nullptr /* translation_manifold */,
                       absl::make_unique<ceres::QuaternionManifold>(),
                       problem));
+#else
+        C_landmarks->emplace(
+            landmark_id,
+            CeresPose(starting_point, nullptr /* translation_parametrization */,
+                      absl::make_unique<ceres::QuaternionParameterization>(),
+                      problem));
+#endif
         // Set landmark constant if it is frozen.
         if (landmark_node.second.frozen) {
           problem->SetParameterBlockConstant(
@@ -274,12 +282,22 @@ void OptimizationProblem3D::Solve(
   ceres::Problem::Options problem_options;
   ceres::Problem problem(problem_options);
 
+#if CERES_VERSION_MAJOR > 2 || CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 1
   const auto translation_manifold =
       [this]() -> std::unique_ptr<ceres::Manifold> {
     return options_.fix_z_in_3d() ? absl::make_unique<ceres::SubsetManifold>(
                                         3, std::vector<int>{2})
                                   : nullptr;
   };
+#else
+  const auto translation_parameterization =
+      [this]() -> std::unique_ptr<ceres::LocalParameterization> {
+    return options_.fix_z_in_3d()
+               ? absl::make_unique<ceres::SubsetParameterization>(
+                     3, std::vector<int>{2})
+               : nullptr;
+  };
+#endif
 
   // Set the starting point.
   CHECK(!submap_data_.empty());
@@ -294,21 +312,40 @@ void OptimizationProblem3D::Solve(
       first_submap = false;
       // Fix the first submap of the first trajectory except for allowing
       // gravity alignment.
+#if CERES_VERSION_MAJOR > 2 || CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 1
       C_submaps.Insert(
           submap_id_data.id,
           CeresPose(submap_id_data.data.global_pose,
                     translation_manifold(),
-                    absl::make_unique<ConstantYawQuaternionManifold>(),
+                    absl::make_unique<ceres::AutoDiffManifold<ConstantYawQuaternionOperations, 4, 2>>(),
                     &problem));
+#else
+      C_submaps.Insert(
+          submap_id_data.id,
+          CeresPose(submap_id_data.data.global_pose,
+                    translation_parameterization(),
+                    absl::make_unique<ceres::AutoDiffLocalParameterization<
+                        ConstantYawQuaternionPlus, 4, 2>>(),
+                    &problem));
+#endif
       problem.SetParameterBlockConstant(
           C_submaps.at(submap_id_data.id).translation());
     } else {
+#if CERES_VERSION_MAJOR > 2 || CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 1
       C_submaps.Insert(
           submap_id_data.id,
           CeresPose(submap_id_data.data.global_pose,
                     translation_manifold(),
                     absl::make_unique<ceres::QuaternionManifold>(),
                     &problem));
+#else
+      C_submaps.Insert(
+          submap_id_data.id,
+          CeresPose(submap_id_data.data.global_pose,
+                    translation_parameterization(),
+                    absl::make_unique<ceres::QuaternionParameterization>(),
+                    &problem));
+#endif
     }
     if (frozen) {
       problem.SetParameterBlockConstant(
@@ -320,11 +357,19 @@ void OptimizationProblem3D::Solve(
   for (const auto& node_id_data : node_data_) {
     const bool frozen =
         frozen_trajectories.count(node_id_data.id.trajectory_id) != 0;
+#if CERES_VERSION_MAJOR > 2 || CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 1
     C_nodes.Insert(
         node_id_data.id,
         CeresPose(node_id_data.data.global_pose, translation_manifold(),
                   absl::make_unique<ceres::QuaternionManifold>(),
                   &problem));
+#else
+    C_nodes.Insert(
+        node_id_data.id,
+        CeresPose(node_id_data.data.global_pose, translation_parameterization(),
+                  absl::make_unique<ceres::QuaternionParameterization>(),
+                  &problem));
+#endif
     if (frozen) {
       problem.SetParameterBlockConstant(C_nodes.at(node_id_data.id).rotation());
       problem.SetParameterBlockConstant(
@@ -360,8 +405,13 @@ void OptimizationProblem3D::Solve(
       }
       TrajectoryData& trajectory_data = trajectory_data_.at(trajectory_id);
 
+#if CERES_VERSION_MAJOR > 2 || CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 1
+      problem.AddParameterBlock(trajectory_data.imu_calibration.data(), 4,
+                                new ceres::QuaternionManifold());
+#else
       problem.AddParameterBlock(trajectory_data.imu_calibration.data(), 4,
                                 new ceres::QuaternionParameterization());
+#endif
       if (!options_.use_online_imu_extrinsics_in_3d()) {
         problem.SetParameterBlockConstant(
             trajectory_data.imu_calibration.data());
@@ -534,6 +584,7 @@ void OptimizationProblem3D::Solve(
           fixed_frame_pose_in_map =
               node_data.global_pose * constraint_pose.zbar_ij.inverse();
         }
+#if CERES_VERSION_MAJOR > 2 || CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 1
         C_fixed_frames.emplace(
             std::piecewise_construct, std::forward_as_tuple(trajectory_id),
             std::forward_as_tuple(
@@ -542,8 +593,22 @@ void OptimizationProblem3D::Solve(
                     Eigen::AngleAxisd(
                         transform::GetYaw(fixed_frame_pose_in_map.rotation()),
                         Eigen::Vector3d::UnitZ())),
-                nullptr, absl::make_unique<YawOnlyQuaternionManifold>(),
+                nullptr, absl::make_unique<ceres::AutoDiffManifold<YawOnlyQuaternionOperations, 4, 1>>(),
                 &problem));
+#else
+        C_fixed_frames.emplace(
+            std::piecewise_construct, std::forward_as_tuple(trajectory_id),
+            std::forward_as_tuple(
+                transform::Rigid3d(
+                    fixed_frame_pose_in_map.translation(),
+                    Eigen::AngleAxisd(
+                        transform::GetYaw(fixed_frame_pose_in_map.rotation()),
+                        Eigen::Vector3d::UnitZ())),
+                nullptr,
+                absl::make_unique<ceres::AutoDiffLocalParameterization<
+                    YawOnlyQuaternionPlus, 4, 1>>(),
+                &problem));
+#endif
         fixed_frame_pose_initialized = true;
       }
 

--- a/cartographer/mapping/internal/optimization/optimization_problem_3d.cc
+++ b/cartographer/mapping/internal/optimization/optimization_problem_3d.cc
@@ -160,8 +160,8 @@ void AddLandmarkCostFunctions(
                                          *prev_node_pose, *next_node_pose);
         C_landmarks->emplace(
             landmark_id,
-            CeresPose(starting_point, nullptr /* translation_parametrization */,
-                      absl::make_unique<ceres::QuaternionParameterization>(),
+            CeresPose(starting_point, nullptr /* translation_manifold */,
+                      absl::make_unique<ceres::QuaternionManifold>(),
                       problem));
         // Set landmark constant if it is frozen.
         if (landmark_node.second.frozen) {
@@ -274,12 +274,11 @@ void OptimizationProblem3D::Solve(
   ceres::Problem::Options problem_options;
   ceres::Problem problem(problem_options);
 
-  const auto translation_parameterization =
-      [this]() -> std::unique_ptr<ceres::LocalParameterization> {
-    return options_.fix_z_in_3d()
-               ? absl::make_unique<ceres::SubsetParameterization>(
-                     3, std::vector<int>{2})
-               : nullptr;
+  const auto translation_manifold =
+      [this]() -> std::unique_ptr<ceres::Manifold> {
+    return options_.fix_z_in_3d() ? absl::make_unique<ceres::SubsetManifold>(
+                                        3, std::vector<int>{2})
+                                  : nullptr;
   };
 
   // Set the starting point.
@@ -298,9 +297,8 @@ void OptimizationProblem3D::Solve(
       C_submaps.Insert(
           submap_id_data.id,
           CeresPose(submap_id_data.data.global_pose,
-                    translation_parameterization(),
-                    absl::make_unique<ceres::AutoDiffLocalParameterization<
-                        ConstantYawQuaternionPlus, 4, 2>>(),
+                    translation_manifold(),
+                    absl::make_unique<ConstantYawQuaternionManifold>(),
                     &problem));
       problem.SetParameterBlockConstant(
           C_submaps.at(submap_id_data.id).translation());
@@ -308,8 +306,8 @@ void OptimizationProblem3D::Solve(
       C_submaps.Insert(
           submap_id_data.id,
           CeresPose(submap_id_data.data.global_pose,
-                    translation_parameterization(),
-                    absl::make_unique<ceres::QuaternionParameterization>(),
+                    translation_manifold(),
+                    absl::make_unique<ceres::QuaternionManifold>(),
                     &problem));
     }
     if (frozen) {
@@ -324,8 +322,8 @@ void OptimizationProblem3D::Solve(
         frozen_trajectories.count(node_id_data.id.trajectory_id) != 0;
     C_nodes.Insert(
         node_id_data.id,
-        CeresPose(node_id_data.data.global_pose, translation_parameterization(),
-                  absl::make_unique<ceres::QuaternionParameterization>(),
+        CeresPose(node_id_data.data.global_pose, translation_manifold(),
+                  absl::make_unique<ceres::QuaternionManifold>(),
                   &problem));
     if (frozen) {
       problem.SetParameterBlockConstant(C_nodes.at(node_id_data.id).rotation());
@@ -544,9 +542,7 @@ void OptimizationProblem3D::Solve(
                     Eigen::AngleAxisd(
                         transform::GetYaw(fixed_frame_pose_in_map.rotation()),
                         Eigen::Vector3d::UnitZ())),
-                nullptr,
-                absl::make_unique<ceres::AutoDiffLocalParameterization<
-                    YawOnlyQuaternionPlus, 4, 1>>(),
+                nullptr, absl::make_unique<YawOnlyQuaternionManifold>(),
                 &problem));
         fixed_frame_pose_initialized = true;
       }

--- a/cartographer/mapping/internal/range_data_collator_test.cc
+++ b/cartographer/mapping/internal/range_data_collator_test.cc
@@ -92,7 +92,7 @@ TEST(RangeDataCollatorTest, SingleSensorEmptyData) {
   const std::string sensor_id = "single_sensor";
   RangeDataCollator collator({sensor_id});
   sensor::TimedPointCloudData empty_data{
-      common::FromUniversal(300), {}, {}, {}};
+      common::FromUniversal(300), Eigen::Vector3f::Zero(), {}, {}};
   auto output_0 = collator.AddRangeData(sensor_id, empty_data);
   EXPECT_EQ(output_0.time, empty_data.time);
   EXPECT_EQ(output_0.ranges.size(), empty_data.ranges.size());

--- a/cartographer/sensor/internal/test_helpers.h
+++ b/cartographer/sensor/internal/test_helpers.h
@@ -47,7 +47,7 @@ struct CollatorInput {
                                      const std::string& sensor_id, int time) {
     return CollatorInput{
         trajectory_id,
-        MakeDispatchable(sensor_id, ImuData{common::FromUniversal(time)}),
+        MakeDispatchable(sensor_id, ImuData{common::FromUniversal(time), Eigen::Vector3d::Zero(), Eigen::Vector3d::Zero()}),
         CollatorOutput{trajectory_id, sensor_id, common::FromUniversal(time)}};
   }
   static CollatorInput CreateTimedPointCloudData(int trajectory_id,


### PR DESCRIPTION
In particular, newer versions of Ceres have removed `ceres::LocalParameterization`, and you are now expected to use `ceres::Manifold` instead.

I took https://github.com/cartographer-project/cartographer/pull/1882 as a starting point.  I then modified things so that this would work with both older ceres (that has `ceres::LocalParameterization`) and newer ceres (that only has `ceres::Manifold`).  I was perhaps overly cautious here, in that I made sure to make no changes for older ceres with the #ifdef sections; the new code is only ever activated for newer ceres.  The reasoning for that was to make sure that this still works for e.g. Humble and Iron, and that there are definitely no regressions there.

I also added a few more changes to fix up some spurious warnings in CMake and in Eigen.  The result should be a successful build on both Ubuntu 22.04 and Ubuntu 24.04.