### PR TITLE
Make sure the cartographer CMake config finds boost.

### DIFF
--- a/cartographer-config.cmake.in
+++ b/cartographer-config.cmake.in
@@ -44,6 +44,8 @@ if(CARTOGRAPHER_HAS_GRPC)
    find_package(async_grpc ${QUIET_OR_REQUIRED_OPTION})
 endif()
 
+find_package(Boost REQUIRED COMPONENTS iostreams)
+
 include("${CARTOGRAPHER_CMAKE_DIR}/CartographerTargets.cmake")
 
 unset(QUIET_OR_REQUIRED_OPTION)


### PR DESCRIPTION
That way downstream components don't need to do this.